### PR TITLE
Fix error/infinite load and disable auto-correction on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         </header>
         <main>
             <h2>Enter any Latin word or sentence</h2>
-            <input type="text" placeholder="Enter any Latin word or sentence here" class="bodyInput" id="lookupInput" autofocus>
+            <input type="text" autocapitalize="off" autocorrect="off" placeholder="Enter any Latin word or sentence here" class="bodyInput" id="lookupInput" autofocus>
             <a class="lookupButton" id="lookup" onclick="lookupText($('.bodyInput').val());">Lookup</a>
             <a class="lookupButton red" onclick="window.open('https://en.wiktionary.org/wiki/' + $('.bodyInput').val() + '#Latin');">Not Working? Lookup on Wiktionary</a>
             <div class="results"></div>

--- a/script.js
+++ b/script.js
@@ -160,7 +160,7 @@ function wikiJS(oldWord, language, scrollTo) {
 }
 
 function lookupText(inputText) {
-    inputText = removeDiacritics(inputText);
+    inputText = removeDiacritics(inputText).toLowerCase();
     $('.results').html('');
     let sentence = isSentence(inputText);
     if (sentence == false) {


### PR DESCRIPTION
When using capital letters in a query it will result in an error/load infinitely. For example:
![old](https://user-images.githubusercontent.com/62816361/118328121-7dfc9c80-b4cb-11eb-950d-0ee0910d5522.gif)

This is fixed by converting the input text to lower case:
![new](https://user-images.githubusercontent.com/62816361/118328360-8f45a900-b4cb-11eb-876b-4989e2fb754b.gif)

Also, I added autocapitalize="off" and autocorrect="off" to the input to solve the issue of similar words in Latin being "corrected" to the language in your phone.