### PR TITLE
Trim whitespace to prevent empty lookup boxes

### DIFF
--- a/script.js
+++ b/script.js
@@ -212,7 +212,7 @@ function lookupText(inputText) {
     if (sentence == false) {
         wikiJS(inputText, 'Latin', false);
     } else if (sentence == true) {
-        let splitInput = inputText.split(' ');
+        let splitInput = inputText.trim().split(' ');
         splitInput.forEach(function (item, index) {
             wikiJS(item, 'Latin', false);
         });


### PR DESCRIPTION
When you have whitespace at the front or back of a query it will generate empty boxes, noticed this when using the site on mobile especially.

Using [trim](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim) I stripped out the whitespace before and after the query. That way when you only get word queries in response.

### Example:
![static-before](https://user-images.githubusercontent.com/62816361/132929960-bcdfeded-d642-4c59-a623-b3f7168207f7.png)

### Before:
![vid-before](https://user-images.githubusercontent.com/62816361/132930057-bdbd8393-2a96-4007-b78f-5986ff8e106d.gif)

### After: 
![vid-after](https://user-images.githubusercontent.com/62816361/132930028-f5a36ede-9b1c-4683-93fd-fb79a1f6ed42.gif)
